### PR TITLE
Fix comments getting lost with concat

### DIFF
--- a/src/array.js
+++ b/src/array.js
@@ -215,6 +215,8 @@ class CommentArray extends Array {
       return ret
     }
 
+    move_comments(ret, this, 0, this.length, 0)
+
     items.forEach(item => {
       const prev = length
       length += isArray(item)

--- a/test/array.test.js
+++ b/test/array.test.js
@@ -357,25 +357,31 @@ test('assign', t => {
 })
 
 test('concat', t => {
-  const parsed = parse(`[
+  const parsed1 = parse(`[
+  // foo
+  "foo"
+]`)
+
+  const parsed2 = parse(`[
   // bar
   "bar",
   // baz,
   "baz"
 ]`)
 
-  const concated = new CommentArray('quux').concat(
-    'qux',
-    parsed
+  const concated = parsed1.concat(
+    parsed2,
+    'qux'
   )
 
   t.is(stringify(concated, null, 2), `[
-  "quux",
-  "qux",
+  // foo
+  "foo",
   // bar
   "bar",
   // baz,
-  "baz"
+  "baz",
+  "qux"
 ]`)
 
   t.is(stringify(new CommentArray().concat()), '[]')


### PR DESCRIPTION
The example in the readme works because the first CommentArray being concatenated does not include a comment:
```javascript
parsed.foo = new CommentArray('quux').concat(parsed.foo)
```

If the first CommentArray being concatenated does include one or more comments, they are lost:
```javascript
const parsedFoo = parse(`[
  // foo
  "foo"
]`)
const parsedBar = parse(`[
  // bar
  "bar"
]`)
const concated = parsedFoo.concat(parsedBar)
stringify(concated, null, 2)
// [
//   "foo",  
//   // bar
//   "bar"
// ]
```

This PR fixes the issue so that comments are preserved, as demonstrated in the updated test.