### PR TITLE
Fix `Query comments in TypeScript` example in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ It is a common use case to sort the keys of a JSON file
 ```js
 const parsed = parse(`{
   // b
-  "b": 2
+  "b": 2,
   // a
   "a": 1
 }`)
@@ -305,14 +305,14 @@ Furthermore, a type `CommentDescriptor` is provided for enforcing properly forma
 
 ```ts
 import {
-  CommentDescriptor, CommentSymbol, parse
+  CommentDescriptor, CommentSymbol, parse, CommentArray
 } from 'comment-json'
 
 const parsed = parse(`{ /* test */ "foo": "bar" }`)
  // typescript only allows properly formatted symbol names here
-const symbolName: CommentDescriptor: 'before-prop:foo'
+const symbolName: CommentDescriptor = 'before:foo'
 
-console.log(parsed[Symbol.for(symbolName) as CommentSymbol][0].value)
+console.log((parsed as CommentArray<string>)[Symbol.for(symbolName) as CommentSymbol][0].value)
 ```
 
 In this example, casting to `Symbol.for(symbolName)` to `CommentSymbol` is mandatory.


### PR DESCRIPTION
Running query comments example was resulting in type errors  : -  

code -  `console.log(parsed[Symbol.for(symbolName) as CommentSymbol][0].value)`
error - 
- error TS18047: 'parsed' is possibly 'null'.`
-  error TS7053:  Element implicitly has an 'any' type because expression of type 'unique symbol' can't be used to index type 'string | number | boolean | CommentArray<CommentJSONValue> | CommentObject'.   Property '["comment-json".commentSymbol]' does not exist on type 'string | number | boolean | CommentArray<CommentJSONValue> | CommentObject'.