### PR TITLE
Fix type for `parse()`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -70,7 +70,7 @@ export type Reviver = (k: number | string, v: unknown) => unknown
  */
 export function parse(
   json: string,
-  reviver?: Reviver,
+  reviver?: Reviver | null,
   removesComments?: boolean
 ): CommentJSONValue
 


### PR DESCRIPTION
Closes #44

It appears that the 2nd argument of `parse()` (`reviver`) can also be `null`, from the examples in the readme and also `src/parse.js`:

https://github.com/kaelzhang/node-comment-json/blob/4416b4dc6bcf446ab09207a0b775ae899a97a10c/src/parse.js#L53