### PR TITLE
Replace repeat-string with builtin

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "array-timsort": "^1.0.3",
     "core-util-is": "^1.0.3",
     "esprima": "^4.0.1",
-    "has-own-prop": "^2.0.0",
-    "repeat-string": "^1.6.1"
+    "has-own-prop": "^2.0.0"
   }
 }

--- a/src/stringify.js
+++ b/src/stringify.js
@@ -1,7 +1,6 @@
 const {
   isArray, isObject, isFunction, isNumber, isString
 } = require('core-util-is')
-const repeat = require('repeat-string')
 
 const {
   PREFIX_BEFORE_ALL,
@@ -308,7 +307,7 @@ const get_indent = space => isString(space)
   // If the space parameter is a string, it will be used as the indent string.
   ? space
   : isNumber(space)
-    ? repeat(SPACE, space)
+    ? SPACE.repeat(space)
     : EMPTY
 
 const {toString} = Object.prototype


### PR DESCRIPTION
`String.repeat` is supported [since Node.js 4](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/repeat#browser_compatibility). It is safe to drop the dependency `repeat-string`.