### PR TITLE
 Add all other LTS versions to test matrix 

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -17,6 +17,7 @@ jobs:
       uses: actions/setup-node@v5
       with:
         node-version: ${{ matrix.node-version }}
+        cache: npm
     - name: npm install, build, lint, and test
       run: |
         npm install

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [18.x, 20.x, 22.x, 24.x]
 
     steps:
     - uses: actions/checkout@v5


### PR DESCRIPTION
Also adds a cache for npm dependencies.

Note: Node.js 18 isn't even supported any more. So we could remove it as well. But that would be a breaking change, so I left it in that list.