### PR TITLE
Replace `has-own-prop` with `Object.hasOwn`

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
   "dependencies": {
     "array-timsort": "^1.0.3",
     "core-util-is": "^1.0.3",
-    "esprima": "^4.0.1",
-    "has-own-prop": "^2.0.0"
+    "esprima": "^4.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "array-timsort": "^1.0.3",
     "core-util-is": "^1.0.3",
     "esprima": "^4.0.1",
-    "has-own-prop": "^2.0.0",
-    "repeat-string": "^1.6.1"
+    "has-own-prop": "^2.0.0"
   }
 }

--- a/src/common.js
+++ b/src/common.js
@@ -1,4 +1,3 @@
-const hasOwnProperty = require('has-own-prop')
 const {
   isObject,
   isArray,
@@ -52,7 +51,7 @@ const copy_comments_by_kind = (
   target, source, target_key, source_key, prefix, remove_source
 ) => {
   const source_prop = symbol(prefix, source_key)
-  if (!hasOwnProperty(source, source_prop)) {
+  if (!Object.hasOwn(source, source_prop)) {
     return
   }
 
@@ -84,7 +83,7 @@ const swap_comments = (array, from, to) => {
 
   SYMBOL_PREFIXES.forEach(prefix => {
     const target_prop = symbol(prefix, to)
-    if (!hasOwnProperty(array, target_prop)) {
+    if (!Object.hasOwn(array, target_prop)) {
       copy_comments_by_kind(array, array, to, from, prefix, true)
       return
     }
@@ -114,7 +113,7 @@ const assign = (target, source, keys) => {
       return
     }
 
-    if (!hasOwnProperty(source, key)) {
+    if (!Object.hasOwn(source, key)) {
       return
     }
 

--- a/src/stringify.js
+++ b/src/stringify.js
@@ -1,7 +1,6 @@
 const {
   isArray, isObject, isFunction, isNumber, isString
 } = require('core-util-is')
-const repeat = require('repeat-string')
 
 const {
   PREFIX_BEFORE_ALL,
@@ -308,7 +307,7 @@ const get_indent = space => isString(space)
   // If the space parameter is a string, it will be used as the indent string.
   ? space
   : isNumber(space)
-    ? repeat(SPACE, space)
+    ? SPACE.repeat(space)
     : EMPTY
 
 const {toString} = Object.prototype

--- a/test/others.test.js
+++ b/test/others.test.js
@@ -1,6 +1,5 @@
 // eslint-disable-next-line import/no-unresolved
 const test = require('ava')
-const hasOwnProperty = require('has-own-prop')
 
 const {parse, stringify, assign} = require('..')
 
@@ -15,7 +14,7 @@ test('#33: assign: should ignore symbol keys', t => {
   const obj = {}
   const key = Symbol.for('before:a')
 
-  t.is(hasOwnProperty(parsed, key), true)
+  t.is(Object.hasOwn(parsed, key), true)
 
   assign(obj, parsed, [key])
 


### PR DESCRIPTION
Follow-up to #55 to further remove dependencies and should be merged afterwards.

Replace `has-own-prop` with `Object.hasOwn`
The [docs of has-own-prop](https://github.com/sindresorhus/has-own-prop) state:
> If you are targeting Node.js 16+ or browsers, use Object.hasOwn() instead.

`Object.hasOwn` is intended for that use, [as per MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn):
> It is recommended over `Object.prototype.hasOwnProperty()` because it works for `null`-prototype
> objects and with objects that have overridden the inherited `hasOwnProperty()` method.
> While it is possible to workaround these problems by accessing
> `Object.prototype.hasOwnProperty()` on another object
> (like `Object.prototype.hasOwnProperty.call(obj, prop)`, `Object.hasOwn()` is more intuitive and concise.