### PR TITLE
Remove core-utils-is

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
   },
   "dependencies": {
     "array-timsort": "^1.0.3",
-    "core-util-is": "^1.0.3",
     "esprima": "^4.0.1"
   }
 }

--- a/src/array.js
+++ b/src/array.js
@@ -1,4 +1,3 @@
-const {isArray} = require('core-util-is')
 const {sort} = require('array-timsort')
 
 const {
@@ -217,7 +216,7 @@ class CommentArray extends Array {
 
     items.forEach(item => {
       const prev = length
-      length += isArray(item)
+      length += Array.isArray(item)
         ? item.length
         : 1
 

--- a/src/common.js
+++ b/src/common.js
@@ -1,6 +1,5 @@
 const {
   isObject,
-  isArray,
   isString,
   isNumber
 } = require('core-util-is')
@@ -168,7 +167,7 @@ module.exports = {
       // We assign non-property comments
       // if argument `keys` is not specified
       assign_non_prop_comments(target, source)
-    } else if (!isArray(keys)) {
+    } else if (!Array.isArray(keys)) {
       throw new TypeError('keys must be array or undefined')
     } else if (keys.length === 0) {
       // Or argument `keys` is an empty array

--- a/src/common.js
+++ b/src/common.js
@@ -44,7 +44,7 @@ const define = (target, key, value) => Object.defineProperty(target, key, {
  * @param {unknown} v
  * @returns {v is NonNullable<object>}
  */
-const is_object = v => typeof v === 'object' && v !== null;
+const is_object = v => typeof v === 'object' && v !== null
 
 const copy_comments_by_kind = (
   target, source, target_key, source_key, prefix, remove_source

--- a/src/common.js
+++ b/src/common.js
@@ -1,7 +1,6 @@
 const {
   isObject,
-  isString,
-  isNumber
+  isString
 } = require('core-util-is')
 
 const PREFIX_BEFORE = 'before'
@@ -108,7 +107,7 @@ const assign_non_prop_comments = (target, source) => {
 // Assign keys and comments
 const assign = (target, source, keys) => {
   keys.forEach(key => {
-    if (!isString(key) && !isNumber(key)) {
+    if (!isString(key) && typeof key !== 'number') {
       return
     }
 

--- a/src/common.js
+++ b/src/common.js
@@ -1,7 +1,4 @@
-const {
-  isObject,
-  isString
-} = require('core-util-is')
+const {isObject} = require('core-util-is')
 
 const PREFIX_BEFORE = 'before'
 const PREFIX_AFTER_PROP = 'after-prop'
@@ -107,7 +104,7 @@ const assign_non_prop_comments = (target, source) => {
 // Assign keys and comments
 const assign = (target, source, keys) => {
   keys.forEach(key => {
-    if (!isString(key) && typeof key !== 'number') {
+    if (typeof key !== 'string' && typeof key !== 'number') {
       return
     }
 

--- a/src/common.js
+++ b/src/common.js
@@ -1,5 +1,3 @@
-const {isObject} = require('core-util-is')
-
 const PREFIX_BEFORE = 'before'
 const PREFIX_AFTER_PROP = 'after-prop'
 const PREFIX_AFTER_COLON = 'after-colon'
@@ -41,6 +39,12 @@ const define = (target, key, value) => Object.defineProperty(target, key, {
   writable: true,
   configurable: true
 })
+
+/**
+ * @param {unknown} v
+ * @returns {v is NonNullable<object>}
+ */
+const is_object = v => typeof v === 'object' && v !== null;
 
 const copy_comments_by_kind = (
   target, source, target_key, source_key, prefix, remove_source
@@ -149,12 +153,14 @@ module.exports = {
   swap_comments,
   assign_non_prop_comments,
 
+  is_object,
+
   assign (target, source, keys) {
-    if (!isObject(target)) {
+    if (!is_object(target)) {
       throw new TypeError('Cannot convert undefined or null to object')
     }
 
-    if (!isObject(source)) {
+    if (!is_object(source)) {
       return target
     }
 

--- a/src/stringify.js
+++ b/src/stringify.js
@@ -1,5 +1,5 @@
 const {
-  isObject, isNumber, isString
+  isObject, isString
 } = require('core-util-is')
 
 const {
@@ -306,7 +306,7 @@ function stringify (key, holder, gap) {
 const get_indent = space => isString(space)
   // If the space parameter is a string, it will be used as the indent string.
   ? space
-  : isNumber(space)
+  : typeof space === 'number'
     ? SPACE.repeat(space)
     : EMPTY
 

--- a/src/stringify.js
+++ b/src/stringify.js
@@ -1,5 +1,5 @@
 const {
-  isArray, isObject, isFunction, isNumber, isString
+  isObject, isFunction, isNumber, isString
 } = require('core-util-is')
 
 const {
@@ -198,7 +198,7 @@ const object_stringify = (value, gap) => {
   let after_comma = EMPTY
   let first = true
 
-  const keys = isArray(replacer)
+  const keys = Array.isArray(replacer)
     ? replacer
     : Object.keys(value)
 
@@ -292,7 +292,7 @@ function stringify (key, holder, gap) {
   // If the type is 'object', we might be dealing with an object or an array or
   // null.
   case 'object':
-    return isArray(value)
+    return Array.isArray(value)
       ? array_stringify(value, gap)
       : object_stringify(value, gap)
 
@@ -344,7 +344,7 @@ module.exports = (value, replacer_, space) => {
   }
 
   // vanilla `JSON.parse` allow invalid replacer
-  if (!isFunction(replacer_) && !isArray(replacer_)) {
+  if (!isFunction(replacer_) && !Array.isArray(replacer_)) {
     replacer_ = null
   }
 

--- a/src/stringify.js
+++ b/src/stringify.js
@@ -1,5 +1,3 @@
-const {isObject} = require('core-util-is')
-
 const {
   PREFIX_BEFORE_ALL,
   PREFIX_BEFORE,
@@ -17,7 +15,9 @@ const {
   COMMA,
   EMPTY,
 
-  UNDEFINED
+  UNDEFINED,
+
+  is_object
 } = require('./common')
 
 // eslint-disable-next-line no-control-regex, no-misleading-character-class
@@ -261,7 +261,7 @@ function stringify (key, holder, gap) {
   let value = holder[key]
 
   // If the value has a toJSON method, call it to obtain a replacement value.
-  if (isObject(value) && typeof value.toJSON === 'function') {
+  if (is_object(value) && typeof value.toJSON === 'function') {
     value = value.toJSON(key)
   }
 
@@ -355,7 +355,7 @@ module.exports = (value, replacer_, space) => {
 
   clean()
 
-  return isObject(value)
+  return is_object(value)
     ? process_comments(value, PREFIX_BEFORE_ALL, EMPTY, true).trimLeft()
       + str
       + process_comments(value, PREFIX_AFTER_ALL, EMPTY).trimRight()

--- a/src/stringify.js
+++ b/src/stringify.js
@@ -1,6 +1,4 @@
-const {
-  isObject, isString
-} = require('core-util-is')
+const {isObject} = require('core-util-is')
 
 const {
   PREFIX_BEFORE_ALL,
@@ -303,7 +301,7 @@ function stringify (key, holder, gap) {
   }
 }
 
-const get_indent = space => isString(space)
+const get_indent = space => typeof space === 'string'
   // If the space parameter is a string, it will be used as the indent string.
   ? space
   : typeof space === 'number'

--- a/src/stringify.js
+++ b/src/stringify.js
@@ -1,5 +1,5 @@
 const {
-  isObject, isFunction, isNumber, isString
+  isObject, isNumber, isString
 } = require('core-util-is')
 
 const {
@@ -263,13 +263,13 @@ function stringify (key, holder, gap) {
   let value = holder[key]
 
   // If the value has a toJSON method, call it to obtain a replacement value.
-  if (isObject(value) && isFunction(value.toJSON)) {
+  if (isObject(value) && typeof value.toJSON === 'function') {
     value = value.toJSON(key)
   }
 
   // If we were called with a replacer function, then call the replacer to
   // obtain a replacement value.
-  if (isFunction(replacer)) {
+  if (typeof replacer === 'function') {
     value = replacer.call(holder, key, value)
   }
 
@@ -344,7 +344,7 @@ module.exports = (value, replacer_, space) => {
   }
 
   // vanilla `JSON.parse` allow invalid replacer
-  if (!isFunction(replacer_) && !Array.isArray(replacer_)) {
+  if (typeof replacer_ !== 'function' && !Array.isArray(replacer_)) {
     replacer_ = null
   }
 

--- a/test/array.test.js
+++ b/test/array.test.js
@@ -1,8 +1,6 @@
 // eslint-disable-next-line import/no-unresolved
 const test = require('ava')
-const {
-  isObject, isString
-} = require('core-util-is')
+const {isObject} = require('core-util-is')
 const {
   parse, stringify, assign, CommentArray
 } = require('..')
@@ -47,7 +45,7 @@ const texpect = (
     t.is(r, ret)
   }
 
-  if (isString(rr)) {
+  if (typeof rr === 'string') {
     t.is(rr, str)
   } else {
     t.is(st(rr), str)

--- a/test/array.test.js
+++ b/test/array.test.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-unresolved
 const test = require('ava')
 const {
-  isFunction, isObject, isString
+  isObject, isString
 } = require('core-util-is')
 const {
   parse, stringify, assign, CommentArray
@@ -305,7 +305,7 @@ CASES.forEach(([d, a, run, e, s]) => {
     const parsed = parse(a)
     const ret = run(parsed)
 
-    const expect = isFunction(e)
+    const expect = typeof e === 'function'
       ? e
       : (tt, r, str) => {
         tt.deepEqual(r, e)

--- a/test/array.test.js
+++ b/test/array.test.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-unresolved
 const test = require('ava')
 const {
-  isFunction, isObject, isString, isArray
+  isFunction, isObject, isString
 } = require('core-util-is')
 const {
   parse, stringify, assign, CommentArray
@@ -315,7 +315,7 @@ CASES.forEach(([d, a, run, e, s]) => {
     expect(
       t,
       // Cleaned return value
-      isArray(ret)
+      Array.isArray(ret)
         // clean ret
         ? [...ret]
         : ret,

--- a/test/array.test.js
+++ b/test/array.test.js
@@ -1,6 +1,5 @@
 // eslint-disable-next-line import/no-unresolved
 const test = require('ava')
-const {isObject} = require('core-util-is')
 const {
   parse, stringify, assign, CommentArray
 } = require('..')
@@ -39,7 +38,7 @@ const texpect = (
   // real return value
   rr
 ) => {
-  if (isObject(ret)) {
+  if (typeof ret === 'object' && ret !== null) {
     t.deepEqual(r, ret)
   } else {
     t.is(r, ret)

--- a/test/stringify.test.js
+++ b/test/stringify.test.js
@@ -2,7 +2,6 @@
 const test = require('ava')
 const {resolve} = require('test-fixture')()
 const fs = require('fs')
-const {isString} = require('core-util-is')
 
 const {parse, stringify} = require('..')
 
@@ -111,7 +110,7 @@ OLD_CASES.forEach(name => {
     3,
     null
   ].forEach(space => {
-    const s = isString(space)
+    const s = typeof space === 'string'
       ? space.length
       : space
 

--- a/test/stringify.test.js
+++ b/test/stringify.test.js
@@ -2,7 +2,7 @@
 const test = require('ava')
 const {resolve} = require('test-fixture')()
 const fs = require('fs')
-const {isFunction, isString} = require('core-util-is')
+const {isString} = require('core-util-is')
 
 const {parse, stringify} = require('..')
 
@@ -69,7 +69,7 @@ const each = (subjects, replacers, spaces, iterator) => {
       spaces.forEach((space, iii) => {
         const desc = [subject, replacer, space]
         .map(s =>
-          isFunction(s)
+          typeof s === 'function'
             ? 'replacer'
             : JSON.stringify(s)
         )


### PR DESCRIPTION
Mostly replaces them with their body or modern replacement (Array.isArray or typeof).

This also opens the ability to use comment-json inside the browser (core-utils-is depended on node:buffer, which is unavailable in browsers).