### PR TITLE
fix: preserve blank line after inline block comment in stringify

### DIFF
--- a/src/stringify.js
+++ b/src/stringify.js
@@ -62,6 +62,26 @@ const count_trailing_line_breaks = str => {
   return count
 }
 
+const count_leading_line_breaks = str => {
+  let i = 0
+  let count = 0
+
+  while (i < str.length) {
+    while (i < str.length && is_inline_whitespace(str[i])) {
+      i ++
+    }
+
+    if (i === str.length || str[i] !== LF) {
+      return count
+    }
+
+    i ++
+    count ++
+  }
+
+  return count
+}
+
 // display_block `boolean` whether the
 //   WHOLE block of comments is always a block group
 const process_comments = (host, symbol_tag, deeper_gap, display_block) => {
@@ -138,8 +158,20 @@ const join = (one, two, gap) =>
       // Symbol.for('before') and Symbol.for('before:prop')
       // might both exist if user mannually add comments to the object
       // and make a mistake.
-      // SO, we are not to only trimRight but trim for both sides
-      ? one + two.trim() + LF + gap
+      // SO, we are not to only trimRight but trim for both sides.
+      // The trailing `LF + gap` plus the trailing line breaks of `one`
+      // already supply some line breaks, so only emit the blank lines that
+      // `two` carries beyond those, otherwise `two.trim()` would drop them.
+      ? one
+        + repeat_line_breaks(
+          Math.max(
+            count_leading_line_breaks(two)
+              - count_trailing_line_breaks(one) - 1,
+            0
+          ),
+          gap
+        )
+        + two.trim() + LF + gap
       : one.trimRight() + repeat_line_breaks(
         Math.max(1, count_trailing_line_breaks(one)),
         gap

--- a/test/stringify.test.js
+++ b/test/stringify.test.js
@@ -219,6 +219,36 @@ test('preserve blank lines after before comments', t => {
   t.is(output, content)
 })
 
+test('preserve blank line after inline block comment following a comma', t => {
+  const content = `{
+  "a": 1, /* x */
+
+  "b": 2
+}`
+
+  t.is(stringify(parse(content), null, 2), content)
+})
+
+test('preserve blank line after inline line comment following a comma', t => {
+  const content = `{
+  "a": 1, // x
+
+  "b": 2
+}`
+
+  t.is(stringify(parse(content), null, 2), content)
+})
+
+test('preserve blank line after inline block comment in arrays', t => {
+  const content = `[
+  1, /* x */
+
+  2
+]`
+
+  t.is(stringify(parse(content), null, 2), content)
+})
+
 test('render explicit BlankLine tokens between comments', t => {
   const comments = [
     {


### PR DESCRIPTION
## The bug

A blank line that follows an inline block comment (`/* ... */`) placed after a comma is silently dropped by `stringify`. The identical construct with a line comment (`// ...`) round-trips correctly.

```js
const {parse, stringify} = require('comment-json')

// inline BLOCK comment after the comma, then a blank line:
const input = '{\n  "a": 1, /* x */\n\n  "b": 2\n}'
stringify(parse(input), null, 2) === input
// false -- the blank line before "b" is lost

// CONTROL: identical shape but a LINE comment round-trips fine:
const ctrl = '{\n  "a": 1, // x\n\n  "b": 2\n}'
stringify(parse(ctrl), null, 2) === ctrl
// true
```

It also reproduces in arrays (`[\n  1, /* x */\n\n  2\n]`) and collapses multiple blank lines to zero.

## Why it is a stringify defect

For both the line- and block-comment inputs, `parse` produces the same structure. The only difference is the comment `type`; the `BlankLine` token in `before:b` is captured identically in both. Yet it renders only in the line-comment case, so the loss happens purely in `stringify`.

## Root cause

In `join()`, the `one && two` branch did:

```js
one + two.trim() + LF + gap
```

Here `two` is the rendered `before:<key>` slot and carries the blank-line count as leading line breaks. `two.trim()` discards them, and the branch hardcodes a single `LF + gap`. The line-comment case survives only because `process_comments` appends a trailing `LF` after a `LineComment`, which lands the missing break in `one` by coincidence; the block-comment case has no such trailing `LF`, so the blank line is lost.

## The fix

Emit the blank lines that `two` carries beyond those already supplied by the trailing `LF + gap` and the trailing line breaks of `one`:

```js
one
  + repeat_line_breaks(
    Math.max(
      count_leading_line_breaks(two)
        - count_trailing_line_breaks(one) - 1,
      0
    ),
    gap
  )
  + two.trim() + LF + gap
```

`count_leading_line_breaks` mirrors the existing `count_trailing_line_breaks` helper. When `two` carries no extra blank lines the clamp yields `0`, so the output is byte-identical to before for every existing case.

## Tests

Added three round-trip tests (block after object property, line-comment control, block in array). The block cases fail on `master` and pass with the fix; the line-comment control passes both ways. The full suite stays green (403 tests, 100% branch coverage on `stringify.js`).
